### PR TITLE
Multiple projects issues

### DIFF
--- a/AutoSortVcxprojFilters/AutoSortPackage.cs
+++ b/AutoSortVcxprojFilters/AutoSortPackage.cs
@@ -191,7 +191,7 @@ namespace AutoSortVcxprojFilters
             {
                 foreach(var proj in projects)
                 {
-                    var obj = sorters.Find(x => { return x.Path == System.IO.Path.GetDirectoryName(proj.FullName); });
+                    var obj = sorters.Find(x => { return x.FullProjectName == proj.FullName; });
                     if (obj != null)
                     {
                         newSorters.Add(obj);

--- a/AutoSortVcxprojFilters/AutoSortVcxprojFilters.csproj
+++ b/AutoSortVcxprojFilters/AutoSortVcxprojFilters.csproj
@@ -54,6 +54,7 @@
     <Compile Include="AutoSortPackage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SortAllCommand.cs" />
+    <Compile Include="SortFilterOnAfterSave.cs" />
     <Compile Include="VCXFilterSorter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/AutoSortVcxprojFilters/SortAllCommand.cs
+++ b/AutoSortVcxprojFilters/SortAllCommand.cs
@@ -93,13 +93,7 @@ namespace AutoSortVcxprojFilters
         /// <param name="e">Event args.</param>
         private void MenuItemCallback(object sender, EventArgs e)
         {
-            package.Sorters.ForEach((x) => x.StopWatching());
-            foreach(var proj in package.GetProjects())
-            {
-                var projName = proj.FullName;
-                VCXFilterSorter.Sort(projName + ".filters");
-            }
-            package.Sorters.ForEach((x) => x.StartWatching());
+            package.Sorters.ForEach((x) => x.Sort() );
         }
     }
 }

--- a/AutoSortVcxprojFilters/SortAllCommand.cs
+++ b/AutoSortVcxprojFilters/SortAllCommand.cs
@@ -6,9 +6,7 @@
 
 using System;
 using System.ComponentModel.Design;
-using System.Globalization;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 
 namespace AutoSortVcxprojFilters
 {
@@ -93,7 +91,12 @@ namespace AutoSortVcxprojFilters
         /// <param name="e">Event args.</param>
         private void MenuItemCallback(object sender, EventArgs e)
         {
-            package.Sorters.ForEach((x) => x.Sort() );
+            var projects = package.GetProjects();
+
+            foreach (var proj in projects)
+            {
+                VCXFilterSorter.Sort(proj.FullName + @".filters");
+            }
         }
     }
 }

--- a/AutoSortVcxprojFilters/SortFilterOnAfterSave.cs
+++ b/AutoSortVcxprojFilters/SortFilterOnAfterSave.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+
+namespace AutoSortVcxprojFilters
+{
+    internal class SortFilterOnAfterSave : IVsRunningDocTableEvents
+    {
+        IVsRunningDocumentTable m_IVsRunningDocumentTable;
+
+        public SortFilterOnAfterSave(IVsRunningDocumentTable i_IVsRunningDocumentTable)
+        {
+            m_IVsRunningDocumentTable = i_IVsRunningDocumentTable;
+        }
+
+        public int OnAfterAttributeChange(uint docCookie, uint grfAttribs)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnAfterDocumentWindowHide(uint docCookie, IVsWindowFrame pFrame)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnAfterFirstDocumentLock(uint docCookie, uint dwRDTLockType, uint dwReadLocksRemaining, uint dwEditLocksRemaining)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnAfterSave(uint docCookie)
+        {
+            uint pgrfRDTFlags, pdwReadLocks, pdwEditLocks, pitemid, e;
+            IVsHierarchy ppHier;
+            IntPtr ppunkDocData;
+
+            string fullDocumentName;
+
+            // Get document name
+            m_IVsRunningDocumentTable.GetDocumentInfo(
+                docCookie,
+                out pgrfRDTFlags,
+                out pdwReadLocks,
+                out pdwEditLocks,
+                out fullDocumentName,
+                out ppHier,
+                out pitemid,
+                out ppunkDocData);
+
+            if (fullDocumentName.EndsWith(@"vcxproj.filters"))
+            {
+                VCXFilterSorter.Sort(fullDocumentName);
+            }
+
+            return VSConstants.S_OK;
+        }
+
+        public int OnBeforeDocumentWindowShow(uint docCookie, int fFirstShow, IVsWindowFrame pFrame)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnBeforeLastDocumentUnlock(uint docCookie, uint dwRDTLockType, uint dwReadLocksRemaining, uint dwEditLocksRemaining)
+        {
+            return VSConstants.S_OK;
+        }
+    }
+}

--- a/AutoSortVcxprojFilters/VCXFilterSorter.cs
+++ b/AutoSortVcxprojFilters/VCXFilterSorter.cs
@@ -1,130 +1,35 @@
-﻿using EnvDTE;
-using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml.Linq;
 
 namespace AutoSortVcxprojFilters
 {
-    class VCXFilterSorter : IDisposable
+    class VCXFilterSorter
     {
-        private string Path { get; set; }
-        private string ProjectName { get; set; }
-        public  string FullProjectName { get; private set; }
-        private string VcxprojFiltersName { get; set; }
-        private string FullVcxprojFiltersName { get; set; }
-
-        private FileSystemWatcher m_FileSystemWatcher;
-
-        public VCXFilterSorter(Project project)
+        public static void Sort(string FullFilePath)
         {
-            ProjectName = System.IO.Path.GetFileName(project.FullName);
-            Path = System.IO.Path.GetDirectoryName(project.FullName);
-
-            FullProjectName = Path + System.IO.Path.DirectorySeparatorChar + ProjectName;
-
-            VcxprojFiltersName = ProjectName + @".filters";
-            FullVcxprojFiltersName = Path + System.IO.Path.DirectorySeparatorChar + VcxprojFiltersName;
-
-            m_FileSystemWatcher = new FileSystemWatcher(Path, VcxprojFiltersName);
-            m_FileSystemWatcher.Created += m_FileSystemWatcher_Created;
-            m_FileSystemWatcher.Changed += m_FileSystemWatcher_Changed;
-            m_FileSystemWatcher.EnableRaisingEvents = true;
-        }
-
-        private void m_FileSystemWatcher_Changed(object sender, FileSystemEventArgs e)
-        {
-            if (e.Name.EndsWith(".vcxproj.filters"))
+            try
             {
-                Sort();
-            }
-        }
-
-        private void m_FileSystemWatcher_Created(object sender, FileSystemEventArgs e)
-        {
-            if (e.Name.EndsWith(".vcxproj.filters"))
-            {
-                Sort();
-            }
-        }
-
-        private void StopWatching()
-        {
-            m_FileSystemWatcher.EnableRaisingEvents = false;
-        }
-
-        private void StartWatching()
-        {
-            m_FileSystemWatcher.EnableRaisingEvents = true;
-        }
-
-        public void Sort()
-        {
-            StopWatching();
-
-            if (System.IO.File.Exists(FullVcxprojFiltersName))
-            {
-                System.Threading.Thread.Sleep(200); // Avoid load fail
-
-                XDocument xmlDocument = XDocument.Load(FullVcxprojFiltersName);
-
-                foreach (var itemgroup in xmlDocument.Root.Elements("{http://schemas.microsoft.com/developer/msbuild/2003}ItemGroup"))
+                if (System.IO.File.Exists(FullFilePath))
                 {
-                    itemgroup.ReplaceNodes(from elem in itemgroup.Elements()
-                                           orderby elem.Attribute("Include")?.Value
-                                           select elem);
-                }
+                    System.Threading.Thread.Sleep(200); // Avoid load fail
 
-                xmlDocument.Save(FullVcxprojFiltersName);
-            }
+                    XDocument xmlDocument = XDocument.Load(FullFilePath);
 
-            StartWatching();
-        }
-
-        #region IDisposable Support
-        private bool disposedValue = false; // To detect redundant calls
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposedValue)
-            {
-                if (disposing)
-                {
-                    // TODO: dispose managed state (managed objects).
-                    if (m_FileSystemWatcher != null)
+                    foreach (var itemgroup in xmlDocument.Root.Elements("{http://schemas.microsoft.com/developer/msbuild/2003}ItemGroup"))
                     {
-                        m_FileSystemWatcher.EnableRaisingEvents = false;
-                        m_FileSystemWatcher.Changed -= m_FileSystemWatcher_Changed;
-                        m_FileSystemWatcher.Created -= m_FileSystemWatcher_Created;
-                        m_FileSystemWatcher.Dispose();
-                        m_FileSystemWatcher = null;
+                        itemgroup.ReplaceNodes(from elem in itemgroup.Elements()
+                                               orderby elem.Attribute("Include")?.Value
+                                               select elem);
                     }
+
+                    xmlDocument.Save(FullFilePath);
                 }
-
-                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-                // TODO: set large fields to null.
-
-                disposedValue = true;
+            }
+            catch(Exception /*e*/)
+            {
+                // Make sure the user is not interrupted
             }
         }
-
-        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-        // ~VCXFilterSorter() {
-        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        //   Dispose(false);
-        // }
-
-        // This code added to correctly implement the disposable pattern.
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(true);
-            // TODO: uncomment the following line if the finalizer is overridden above.
-            // GC.SuppressFinalize(this);
-        }
-        #endregion
     }
 }


### PR DESCRIPTION
1. VCXFilterSorter.cs:
FileSystemWatcher invokes 'Change' events for any vcxproj file changed in the directory, when we have multiple projects in the same directory, this cause end-less events loop.
  a. Changed the FileSystemWatcher filter.
  b. 'Sort()' should not be static, and handle enable / disable raising event, and have his own vcxproj.filters 
      file name.

2. AutoSortPackage.cs:
In 'UpdateTrackedFilters()', Find returns wrong obj if the 'projects' array order changed after loading more projects.

3. SortAllCommand.cs:
In 'MenuItemCallback()', Using 'Sort()' will handle disable / enable raising events.

--------------------------------------------------------------------------------------------------
### **Edit:**
Add more commit to catch OnAfterSave event for files, not need using FileSystemWatcher at all.